### PR TITLE
Conforming better to specs, and speed bump.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__
 .pytest_cache
 .coverage
+build
 
 # C
 *.so

--- a/README.md
+++ b/README.md
@@ -39,6 +39,48 @@ decoded = qjson5.loads(encoded)
 print(f"Decoded: {decoded}")
 ```
 
+### Complex Usage
+
+```json5
+{
+  // comments
+  unquoted: 'and you can quote me on that',
+  singleQuotes: 'I can use "double quotes" here',
+  lineBreaks: "Look, Mom! \
+No \\n's!",
+  hexadecimal: 0xdecaf,
+  leadingDecimalPoint: .8675309, andTrailing: 8675309.,
+  positiveSign: +1,
+  trailingComma: 'in objects', andIn: ['arrays',],
+  "backwardsCompatible": "with JSON",
+}
+```
+
+```python
+import qjson5
+
+with open("in.json5") as f_in:
+    with open("out.json", "w") as f_out:
+        qjson5.dump(qjson5.load(f_in), f_out, indent=4)
+```
+
+```json
+{
+    "unquoted": "and you can quote me on that",
+    "singleQuotes": "I can use \"double quotes\" here",
+    "lineBreaks": "Look, Mom! No \\n's!",
+    "hexadecimal": 912559,
+    "leadingDecimalPoint": 0.8675309,
+    "andTrailing": 8675309,
+    "positiveSign": 1,
+    "trailingComma": "in objects",
+    "andIn": [
+        "arrays"
+    ],
+    "backwardsCompatible": "with JSON"
+}
+```
+
 ## Benchmark
 
 Comparing with the other JSON5 libraries:
@@ -51,23 +93,25 @@ Non-JSON5 library:
 * [json](https://docs.python.org/3/library/json.html) (built-in)
 
 ```bash
+==== JSON Libraries Dump+Load Benchmark ====
+
 --- Data Set: SMALL (10 keys per level, 2 levels) ---
 json5        => Skipped
-builtin-json => avg: 15.2858 ms (std: 0.3651 ms) over 1000 iterations
-pyjson5      => avg: 15.7470 ms (std: 0.3296 ms) over 1000 iterations
-qjson5       => avg: 7.6033 ms (std: 0.1131 ms) over 1000 iterations
+builtin-json => avg: 14.1933 ms (std: 0.5063 ms) over 1000 iterations
+pyjson5      => avg: 11.7564 ms (std: 0.1826 ms) over 1000 iterations
+qjson5       => avg: 8.4363 ms (std: 0.0669 ms) over 1000 iterations
 
 --- Data Set: MEDIUM (100 keys per level, 10 levels) ---
 json5        => Skipped
-builtin-json => avg: 169.5224 ms (std: 1.3099 ms) over 500 iterations
-pyjson5      => avg: 207.0516 ms (std: 0.6961 ms) over 500 iterations
-qjson5       => avg: 105.7047 ms (std: 1.4205 ms) over 500 iterations
+builtin-json => avg: 150.4009 ms (std: 1.8448 ms) over 500 iterations
+pyjson5      => avg: 147.5031 ms (std: 0.8454 ms) over 500 iterations
+qjson5       => avg: 98.7803 ms (std: 0.3422 ms) over 500 iterations
 
 --- Data Set: LARGE (1000 keys per level, 50 levels) ---
 json5        => Skipped
-builtin-json => avg: 179.8407 ms (std: 2.6937 ms) over 10 iterations
-pyjson5      => Error: Maximum nesting level exceeded
-qjson5       => avg: 119.5468 ms (std: 0.4641 ms) over 10 iterations
+builtin-json => avg: 150.6014 ms (std: 3.4461 ms) over 10 iterations
+pyjson5      => Error: Maximum nesting level exceeded near 4642
+qjson5       => avg: 99.5796 ms (std: 0.9641 ms) over 10 iterations
 ```
 
 See `scripts/benchmark.py` for benchmarking details.

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -18,14 +18,15 @@ To run:
     python scripts/benchmark.py
 """
 
-import time
-import statistics
-import random
-import string
-
 import json
-import pyjson5
+import random
+import statistics
+import string
+import time
+
 import json5
+import pyjson5
+
 import qjson5
 
 random.seed(0)
@@ -138,6 +139,8 @@ def run_benchmark(
                     duration = time_library(lib_label, func, data_obj, iterations)
                     timings.append(duration)
             except Exception as e:
+                if getattr(e, "message"):
+                    e = e.message
                 print(f"{lib_label:12s} => Error: {e}")
                 continue
             avg_time = statistics.mean(timings)

--- a/tests/test_qjson5.py
+++ b/tests/test_qjson5.py
@@ -1,10 +1,7 @@
 import io
-<<<<<<< HEAD
 import textwrap
-=======
 
 import pytest
->>>>>>> origin/main
 
 import qjson5
 


### PR DESCRIPTION
Conformed to the 'kitchen-sink' example in the json5.org website;

```json5
{
  // comments
  unquoted: 'and you can quote me on that',
  singleQuotes: 'I can use "double quotes" here',
  lineBreaks: "Look, Mom! \
No \\n's!",
  hexadecimal: 0xdecaf,
  leadingDecimalPoint: .8675309, andTrailing: 8675309.,
  positiveSign: +1,
  trailingComma: 'in objects', andIn: ['arrays',],
  "backwardsCompatible": "with JSON",
}
```

and small optimizations for ~10ms speed bump on bechmark.